### PR TITLE
Fix for current RVM

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -4,8 +4,7 @@ function rvm -d 'Ruby enVironment Manager'
   bash -c 'source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
-  and eval (grep '^rvm\|^[^=]*PATH' $env_file | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/')
-
+  and eval (grep '^rvm\|^[^=]*PATH' $env_file | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
   # clean up
   rm -f $env_file
 end


### PR DESCRIPTION
Removed parentheses in the environment variables taken from rvm (bash), since fish interprets them as subcommands
