### PR TITLE
Include GEM_HOME when copying rvm environment variables

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -4,7 +4,7 @@ function rvm -d 'Ruby enVironment Manager'
   bash -c 'source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
-  and eval (grep '^rvm\|^[^=]*PATH' $env_file | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
+  and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
   # clean up
   rm -f $env_file
 end


### PR DESCRIPTION
Hi - I had problems with my setup (OS X 10.7.4, rvm 1.14.2, fishfish beta r2, and ruby 1.9.3) when trying to get rvm & fish to play nicely together.  GEM_PATH was getting set to the regular rvm values (`/Users/jon/.rvm/gems/ruby-1.9.3-p194:/Users/jon/.rvm/gems/ruby-1.9.3-p194@global`), but GEM_HOME was being left at `/Users/jon/.gem`.   So any new gem installations ended up in the wrong directory, and weren't found in the gem path.

How about the attached patch?  I confess I'm not quite sure what the sed command in the latter half of that line is doing, so it could maybe use some sanity checking before you pull it.
