### PR TITLE
cd command without arguments should switch to home directory

### DIFF
--- a/functions/cd.fish
+++ b/functions/cd.fish
@@ -2,7 +2,7 @@ function cd --description "Change working directory"
   # Source a .rvmrc file in a directory after changing to it, if it exists.
   # To disable this fature, set rvm_project_rvmrc=0 in $HOME/.rvmrc
 
-  builtin cd "$argv"
+  builtin cd $argv
   if test "$rvm_project_rvmrc" != 0
     set -l cwd $PWD
     while true


### PR DESCRIPTION
if I am in some other directory

just typing "cd" should get me to my home dir. This patch enables it.

I tested with with directories that have spaces so quotes are not necessary.
