### PR TITLE
rvm.fish fails because of color-related vars

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -4,7 +4,7 @@ function rvm -d 'Ruby enVironment Manager'
   bash -c 'source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
-  and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
+  and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
   # clean up
   rm -f $env_file
 end


### PR DESCRIPTION
I have some vars in my env that make the script choke:

```
rvm_error_clr=
rvm_notify_clr=
rvm_reset_clr=
rvm_debug_clr=
```

They seem to be related to color-coding rvm output. When I remove them, the env gets updated correcty. Otherwise, I get the following error:

```
fish: Tokenizer error: “Unexpected end of string, parenthesis do not match”
```
