### PR TITLE
Fix a malformed if statement in the function rvm

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -21,7 +21,7 @@ function __handle_rvmrc_stuff --on-variable PWD
         end
         break
       else
-        if test -s ".rvmrc"; or test -s ".ruby-version"; or test -s ".ruby-gemset"
+        if begin; test -s ".rvmrc"; or test -s ".ruby-version"; or test -s ".ruby-gemset"; end
           eval "rvm reload" > /dev/null
           break
         else


### PR DESCRIPTION
The rvm function does not execute "rvm reload" when the new directory
contains a .ruby-version file, because the malformed if statement just
looks for a .rvmrc file.

Fish's syntax for if statements with several conditions is the following:
  if begin; CONDITION1; [and|or] CONDITION2; ...; end
rather than:
  if CONDITION1; [and|or] CONDITION2; ...
