### PR TITLE
Fix: entries with space on PATH would break

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -4,7 +4,7 @@ function rvm --description='Ruby enVironment Manager'
   bash -c 'source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
-  and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/y/:/ /; s/^/set -xg /; s/=/ /; s/$/ ;/; s/(//; s/)//')
+  and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//')
   # clean up
   rm -f $env_file
 end


### PR DESCRIPTION
If you have any entries on your path with space, the old version would break those entries into several ones. This PR fixes that issue.
