### PR TITLE
Update rvm.fish

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -23,6 +23,7 @@ function __handle_rvmrc_stuff --on-variable PWD
       else
         if begin; test -s ".rvmrc"; or test -s ".ruby-version"; or test -s ".ruby-gemset"; end
           eval "rvm reload" > /dev/null
+          eval "rvm rvmrc load" >/dev/null
           break
         else
           set cwd (dirname "$cwd")


### PR DESCRIPTION
At least in my environment `rvm reload` is not enough to make it load the `.ruby-version file`. I don't know if it has anything to do with the rvm version (I'm using 1.25.25). but `rvm rvmrc load` does work. 
