### PR TITLE
Fixes #18 & #19 - no env data 'cause of bail & alt path

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -1,7 +1,7 @@
 function rvm --description='Ruby enVironment Manager'
   # run RVM and capture the resulting environment
   set --local env_file (mktemp -t rvm.fish.XXXXXXXXXX)
-  bash -c 'source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
+  bash -c 'PATH=$GEM_HOME/bin:$PATH;source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
   and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//')

--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -1,7 +1,7 @@
 function rvm --description='Ruby enVironment Manager'
   # run RVM and capture the resulting environment
   set --local env_file (mktemp -t rvm.fish.XXXXXXXXXX)
-  bash -c 'PATH=$GEM_HOME/bin:$PATH;source ~/.rvm/scripts/rvm; rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
+  bash -c 'PATH=$GEM_HOME/bin:$PATH;source $(which rvm | sed "s/bin/scripts/"); rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
   and eval (grep '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//')


### PR DESCRIPTION
`rvm` crashes out with a warning if `$GEM_HOME/bin` isn't the first `$PATH` value which then doesn't allow any environment variables to be created for this script to utilize.  RVM will work here by simply placing the value it expects in the beginning of the `PATH` environment variable for the temporary environment that this is grabbing data from.

https://github.com/lunks/fish-nuggets/pull/21/commits/c2cc5abc07278b95345a4b52a2e741260726c727 Fixes #19

RVM isn't always installed in the home directory.  This update uses RVM's `scripts/rvm` where-ever it is.

https://github.com/lunks/fish-nuggets/pull/21/commits/0a2bdfa36f583e472790bebed5b4fb7e172a86a6 Fixes #18