### PR TITLE
Add support for when RVM's not in exec path

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -1,7 +1,7 @@
 function rvm --description='Ruby enVironment Manager'
   # run RVM and capture the resulting environment
   set --local env_file (mktemp -t rvm.fish.XXXXXXXXXX)
-  bash -c 'PATH=$GEM_HOME/bin:$PATH;source $(which rvm | sed "s/bin/scripts/"); rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
+  bash -c 'PATH=$GEM_HOME/bin:$PATH;source $(if test "$(which rvm)";then which rvm | sed "s/bin/scripts/";else whereis rvm | sed "s/rvm: //" | sed "s/rvm/rvm\/scripts\/rvm/"; fi); rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
   and eval (grep -E '^rvm\|^[^=]*PATH\|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//')


### PR DESCRIPTION
During a Docker install of RVM the rvm executable isn't found in the
PATH with the which command.  But whereis will return the RVM directory just fine.  This fix will
allow RVM to work with either and fixes Docker support.