### PR TITLE
Allow Gemfiles to set the Ruby version for RVM

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -25,7 +25,7 @@ function __handle_rvmrc_stuff --on-variable PWD
         end
         break
       else
-        if test -e .rvmrc -o -e .ruby-version -o -e .ruby-gemset
+        if test -e .rvmrc -o -e .ruby-version -o -e .ruby-gemset -o -e Gemfile
           eval "rvm reload" > /dev/null
           eval "rvm rvmrc load" >/dev/null
           break


### PR DESCRIPTION
Standard `bash` operation of `rvm` will set the Ruby version automatically when you change the `pwd` and the Gemfile indicates a specific version is to be used.

This addition allows that behavior to apply in the `fish` shell as well.