### PR TITLE
Use login bash shell (for RVM function)

### DIFF
--- a/functions/rvm.fish
+++ b/functions/rvm.fish
@@ -2,7 +2,7 @@ function rvm --description='Ruby enVironment Manager'
   # run RVM and capture the resulting environment
   set --local env_file (mktemp -t rvm.fish.XXXXXXXXXX)
   # This finds where RVM's root directory is and sources scripts/rvm from within it.  Then loads RVM in a clean environment and dumps the environment variables it generates out for us to use. 
-  bash -c 'PATH=$GEM_HOME/bin:$PATH;RVMA=$(which rvm);RVMB=$(whereis rvm | sed "s/rvm://");source $(if test $RVMA;then echo $RVMA | sed "s/\/bin\//\/scripts\//";elif test $RVMB; then echo $RVMB | sed "s/rvm/rvm\/scripts\/rvm/"; else echo ~/.rvm/scripts/rvm; fi); rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
+  bash -l -c 'PATH=$GEM_HOME/bin:$PATH;RVMA=$(which rvm);RVMB=$(whereis rvm | sed "s/rvm://");source $(if test $RVMA;then echo $RVMA | sed "s/\/bin\//\/scripts\//";elif test $RVMB; then echo $RVMB | sed "s/rvm/rvm\/scripts\/rvm/"; else echo ~/.rvm/scripts/rvm; fi); rvm "$@"; status=$?; env > "$0"; exit $status' $env_file $argv
 
   # apply rvm_* and *PATH variables from the captured environment
   and eval (grep -E '^rvm|^PATH|^GEM_PATH|^GEM_HOME' $env_file | grep -v '_clr=' | sed '/^[^=]*PATH/s/:/" "/g; s/^/set -xg /; s/=/ "/; s/$/" ;/; s/(//; s/)//')


### PR DESCRIPTION
Currently if I login with SSH with fish as default shell then I get error
```
myhost ~> ssh otherhost
Have a lot of fun...
Last login: Thu Jan 23 18:53:44 2025
which: no rvm in (/bin:/usr/bin:/bin:/usr/sbin:/sbin)
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
otherhost ~>
```

Notice `which: no rvm in (/bin:/usr/bin:/bin:/usr/sbin:/sbin)` which happens every time I login.

I think reason is because `bash` without --login doesn't run `/etc/profile.d/` scripts so RVM is not added to PATH yet.
This PR fixes this issue by running `bash -l` and then I don't have such issue anymore.
